### PR TITLE
Add an option for custom data object name (dataObjName)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ module.exports = {
                     escape: /\{\{([\s\S]+?)\}\}/,
                     interpolate: /\{\!([\s\S]+?)\!\}/
                 },
+                
+                // use dataObjName option to define the name of the data object
+                // for templates. It's "data" by default.
+                dataObjName: 'templateData',
 
                 // use the globals option to define variables that
                 // should not be prefixed

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -42,7 +42,7 @@ module.exports = function(content) {
     }
 
     // Compile template
-    var templateSource = _.template(content, { variable: "data" }).source;
+    var templateSource = _.template(content, { variable: query.dataObjName || "data" }).source;
 
     // If a babel config was provided, apply the transforms
     if (typeof query.babel !== 'undefined') {
@@ -118,7 +118,7 @@ function updateIdentifiersInTemplate(source, query) {
             declaredIds.push(node.name)
         }
         else if (!_.contains(declaredIds, node.name) && testForIdentifier(node)) {
-            node.update('data.' + node.source());
+            node.update((query.dataObjName || 'data') + '.' + node.source());
         }
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -54,6 +54,18 @@ describe('underscore-template-strict-loader', () => {
         expect(template({ foo: 'bar' })).to.equal('bar');
     });
 
+    it('prefixes variables with custom data object name', () => {
+        let output = load('<%= foo %>', {
+            query: {
+                dataObjName: 'templateData'
+            },
+        });
+        let template = getTemplateFunction(output);
+
+        expect(output.indexOf('templateData.foo')).to.not.equal(-1);
+        expect(template({ foo: 'bar' })).to.equal('bar');
+    });
+
     it('correctly prefixes objects in the template', () => {
         let output = load('<%= foo.bar %>');
         let template = getTemplateFunction(output);


### PR DESCRIPTION
Now the loader defines a data object with the name "data" for a template. It can cause an exception if a variable with the name "data" was already defined in an external namespace:

`Uncaught TypeError: Identifier 'data' has already been declared`

Using a variable with the name "data" could be usual case in a big project, and when you try to migrate this project to a new version of Webpack and this strict loader (as I did), you can face this error.

So, I think, **an option for the loader that make it able to use a custom name for the data object**, is an useful feature here.